### PR TITLE
AWS VPN `Server` tanúsítvány létrehozás frissítése

### DIFF
--- a/network.md
+++ b/network.md
@@ -432,7 +432,7 @@ AWS Cli telepítésének és beállításának lépéseit megtalálod [itt](./cl
 
 ### Tanúsítvány importálás
 
-1. Lépjünk be abba a mappába ahol a tanúsítványok vannak. Pl.: `Desktop\awscert`
+1. Lépjünk be abba a mappába ahol a tanúsítványok vannak. Pl.: `Desktop\vpncert`
 
 2. Szerver tanúsítvány importálás
 

--- a/network.md
+++ b/network.md
@@ -396,7 +396,7 @@ Megjegyzés: Add meg a felhasználóneved vagy a cég nevét. (ékezet nékül)
 3.3.
 
 ```bash
-./easyrsa build-server-full server nopass
+./easyrsa --san=DNS:server build-server-full server nopass
 ```
 
 Megjegyzés:
@@ -461,6 +461,11 @@ Eredmény:
   "CertificateArn": "arn:aws:acm:eu-central-1:xxxxxxxxxxxx:certificate/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 }
 ```
+
+Az importálás sikerességét az AWS Console-ban is ellenőrizhetjük a AWS Certificate Manager (ACM) szolgáltatásnál. Például:
+
+- a Frankfúrti régióban: [AWS ACM](https://eu-central-1.console.aws.amazon.com/acm/home?region=eu-central-1#/certificates/list)
+- a Stockholmi régióban: [AWS ACM](https://eu-north-1.console.aws.amazon.com/acm/home?region=eu-north-1#/certificates/list)
 
 ### CloudWatch beállítás (Opcionális)
 
@@ -621,4 +626,3 @@ verify-x509-name server name
 17. Megjelenik az üdvözlő üzenetünk. Sikeresen csatlakoztunk.
 
 ![AWS VPN Profile](./images/aws-vpn-connect.png)
-````

--- a/network.md
+++ b/network.md
@@ -464,8 +464,8 @@ Eredmény:
 
 Az importálás sikerességét az AWS Console-ban is ellenőrizhetjük a AWS Certificate Manager (ACM) szolgáltatásnál. Például:
 
-- a Frankfúrti régióban: [AWS ACM](https://eu-central-1.console.aws.amazon.com/acm/home?region=eu-central-1#/certificates/list)
-- a Stockholmi régióban: [AWS ACM](https://eu-north-1.console.aws.amazon.com/acm/home?region=eu-north-1#/certificates/list)
+- a Frankfrt régióban: [AWS ACM](https://eu-central-1.console.aws.amazon.com/acm/home?region=eu-central-1#/certificates/list)
+- a Stockholm régióban: [AWS ACM](https://eu-north-1.console.aws.amazon.com/acm/home?region=eu-north-1#/certificates/list)
 
 ### CloudWatch beállítás (Opcionális)
 

--- a/network.md
+++ b/network.md
@@ -346,7 +346,7 @@ Ezze lszűrjük a privát subnet forgalmát. Csak a szükséges portokat engedj�
 
 ### A. Linux és MacOS
 
-_Megjegyzés: Windows esetén is tudjuk ezt a módszert használni, ha a WSL-t vagy a Git Bash-t használjuk._
+_Megjegyzés: Windows esetén is tudjuk ezt a módszert használni, ha a WSL-t vagy a Git Bash-t használjuk. (WSL telepítése)[dism.exe /online /enable-feature /featurename:VirtualMachinePlatform](https://github.com/cloudsteak/trn-docker?tab=readme-ov-file#docker-desktop-telepítése) /all /norestart_
 
 ```bash
 chmod +x scripts/vpn_certificates.sh

--- a/scripts/easyrsa_shell.ps1
+++ b/scripts/easyrsa_shell.ps1
@@ -1,40 +1,42 @@
- #PowerShell
+#PowerShell
 
- Write-Host "####### Easy RSA #######" -ForegroundColor Green
+Write-Host "####### Easy RSA #######" -ForegroundColor Green
 
 $repo = "OpenVPN/easy-rsa"
-$file = "EasyRSA-3.1.7-win64.zip"
-
+  
 $releases = "https://api.github.com/repos/$repo/releases"
-
+  
 Write-Host Keres: Friss csomag
 $tag = (Invoke-WebRequest $releases | ConvertFrom-Json)[0].tag_name
-
+  
+$version = $tag.Replace("v", "")
+$file = "EasyRSA-$version-win64.zip"
 $download = "https://github.com/$repo/releases/download/$tag/$file"
 $name = $file.Split(".")[0]
 $zip = "$name-$tag.zip"
 $dir = "$name-$tag"
-$version = $tag.Replace("v", "")
-
+  
 Write-Host Beszerez: Friss csomag ($tag)
 Invoke-WebRequest $download -Out $zip
-
+  
 Write-Host Unzip
 Expand-Archive $zip -Force
-
-
+  
+  
 Write-Host easyrsa mappa
 Remove-Item easyrsa -Recurse -Force -ErrorAction SilentlyContinue
 Start-Sleep -Seconds 2
 New-Item -ItemType Directory easyrsa -ErrorAction SilentlyContinue
-
+  
 Move-Item $dir\EasyRSA-$version\* -Destination easyrsa -Force 
-
+  
 # Removing temp files
 Remove-Item $zip -Force
 Remove-Item $dir -Recurse -Force
-
-Write-Host "####### Start Shell #######" -ForegroundColor Green
-
+  
+Write-Host "####### Mappa: easyrsa #######" -ForegroundColor Green
+  
 # Set working directory
 Set-Location -Path easyrsa
+   
+  


### PR DESCRIPTION
Módosítások:
- EasyRSA legfrissebb verziójának letöltése, most már mindig sikeres. (`scripts/easyrsa_shell.ps1`)
- AWS frissítette a `server` tanúsítvány létrehozási folyamatot, ezért a hozzátartozó parancs is frissítve lett. (`network.md`)
- A VPN tanúsítványok importálásának sikerességét az AWS Console-ban is ellenőrizhetjük a AWS Certificate Manager (ACM) szolgáltatásnál. Ezzel adtam pár linket. (`network.md`)